### PR TITLE
A slew of fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 #*
 *#
 .#*
+node_modules

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "mockery": "^1.7.0"
   },
   "peerDependencies": {
     "jsdoc": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "A JSdoc plugin that automates the naming of modules.",
   "main": "index.js",
   "dependencies": {
-    "chai": "^3.5.0",
     "glob": "^7.0.6",
     "jsdoc": "^3.4.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "mocha": "^3.0.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "A JSdoc plugin that automates the naming of modules.",
   "main": "index.js",
   "dependencies": {
-    "glob": "^7.0.6",
-    "jsdoc": "^3.4.0"
+    "glob": "^7.0.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.0.2"
+  },
+  "peerDependencies": {
+    "jsdoc": "^3.4.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --reporter spec"


### PR DESCRIPTION
The one major change is the use of `jsdoc/env` for getting the configuration instead of parsing the command line. Parsing the command line breaks the isolation of concerns. Also the original code would read the configuration file with every file that was processed by jsdoc and would reparse the JSON every time. That was *very* inefficient. Mocking `jsdoc/env` in testing also eliminated the need to have `visitNode` take a test configuration, and since a test configuration was no longer passed, there was no way to know whether the code was running in testing or not so it no longer returns a value in testing. The test suite was adjusted accordingly.

Unless there is really no other way (or the "other way" is inordinately expensive), production code should work in the same way in testing as it does in production. The test suite should accommodate the needs of the code under test rather than the other way around. (Sometimes there is no other way, but that was not the case here.)

See individual commits for other minor changes.